### PR TITLE
Fix broken r link

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,10 +6,17 @@
 #
 # Uses http://cran.rstudio.com as source as this should redirect to a local mirror.
 class r {
+  $version = '3.1.3'
 
-  package { 'R_3_0_2':
+  if (versioncmp($::macosx_productversion_major, '10.9') >= 0) {
+    $macv = 'mavericks'
+  } else {
+    $macv = 'snowleopard'
+  }
+
+  package { 'R':
     provider => 'pkgdmg',
-    source => 'http://cran.r-project.org/bin/macosx/R-3.0.2.pkg',
+    source => "http://cran.r-project.org/bin/macosx/R-${version}-${macv}.pkg",
     ensure => present,
   }
 


### PR DESCRIPTION
Now requires a mac version string as part of the URL.
